### PR TITLE
[BUG] Adds Github Actions PR permission so that PR comments work

### DIFF
--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   preview-environment:
     name: "Build and Deploy Preview Environment"
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     env:
       tfcWorkspaceName: hcup-be-${{ github.head_ref }}


### PR DESCRIPTION
When you try to follow the instructions in https://developer.hashicorp.com/terraform/tutorials/aws/preview-environments-vercel#create-preview-environment you get an error in the `Create comment with Terraform output` action, which fails with `RequestError [HttpError]: Resource not accessible by integration` [seen here.](https://github.com/SrzStephen/learn-terraform-preview-environment/actions/runs/4342172827/jobs/7583125440#step:7:71)

This is fixable by adding the `pull-requests: write` permission to github actions as [shown here](https://github.com/SrzStephen/learn-terraform-preview-environment/actions/runs/4342594119/workflow)

Note: using the `issues` permission won't work as it's not scoped correctly as [shown here](https://github.com/SrzStephen/learn-terraform-preview-environment/actions/runs/4342464854/workflow)



